### PR TITLE
Fix hang when switching to Notes

### DIFF
--- a/info.plist
+++ b/info.plist
@@ -895,9 +895,11 @@ fi</string>
 			<key>config</key>
 			<dict>
 				<key>applescript</key>
-				<string>-- This script takes "URLs" of format "identifier,itemID,accountID,itemFolderID,userQuery" or just "userQuery"-- accountID can be the string "null", if so the default account is used-- Some commands need to run twice, otherwise they fail when toolbar search is activeon alfred_script(q)	try		if q contains "/ICNote/p" or q contains "/ICFolder/p" then			set AppleScript's text item delimiters to ","			set identifier to text item 1 of q			set itemID to text item 2 of q			set accountID to text item 3 of q			set itemFolderID to text item 4 of q			set AppleScript's text item delimiters to ""			tell application "Notes"				if itemID contains "/ICNote/p" then
+				<string>-- This script takes "URLs" of format "identifier,itemID,accountID,itemFolderID,userQuery" or just "userQuery"-- accountID can be the string "null", if so the default account is used-- Some commands need to run twice, otherwise they fail when toolbar search is activeon alfred_script(q)	try		if q contains "/ICNote/p" or q contains "/ICFolder/p" then			set AppleScript's text item delimiters to ","			set identifier to text item 1 of q			set itemID to text item 2 of q			set accountID to text item 3 of q			set itemFolderID to text item 4 of q			set AppleScript's text item delimiters to ""			tell application "Notes"
+				activate				if itemID contains "/ICNote/p" then
 					if itemFolderID is not "null" then						if accountID is "null" then							show folder id itemFolderID in default account						else							show folder id itemFolderID in account id accountID						end if
 					end if					-- Show user-requested note					open location "notes://showNote?identifier=" &amp; identifier					open location "notes://showNote?identifier=" &amp; identifier					-- Compatibility with macOS &lt; 11 which does not support notes://					set OSVersion to system version of (system info)					set mainVersion to text 1 thru ((offset of "." in OSVersion) - 1) of OSVersion as number					if mainVersion &lt; 11 then						if accountID is "null" then							show note id itemID in default account							show note id itemID in default account						else							show note id itemID in account id accountID							show note id itemID in account id accountID						end if					end if				else if itemID contains "/ICFolder/p" then					-- Show user-requested folder					if accountID is "null" then						show folder id itemID in default account						show folder id itemID in default account					else						show folder id itemID in account id accountID						show folder id itemID in account id accountID					end if				end if			end tell					else			tell application "Notes"
+				activate
 				show default folder in default account
 				show default folder in default account
 				delay 0.5 -- to avoid any still-pressed keys interfering
@@ -994,6 +996,7 @@ end alfred_script</string>
 on alfred_script(q)
 	try
 		tell application "Notes"
+			activate
 			show default folder in default account
 			show default folder in default account
 			delay 0.5 -- to avoid any still-pressed keys interfering


### PR DESCRIPTION
# Issue

In some configurations, the workflow can hang for a very long time (a dozen seconds, or sometimes even indefinitely) when performing an action that opens Notes.

# This PR

The hang can be skipped by the user simply by manually switching to Notes. This PR explicitely reveals the Notes app whenever it is supposed to be switched to, thus fixing the issue.

As a side effect, this makes the workflow feel more reactive, as the Notes app will instantly be displayed when the workflow is used, even if it then takes a bit of time to focus the actual requested note.

# Notes

In my daily usage, I only use a fraction of this workflow's features—please test drive this PR for a bit, in case I missed issues with it!

Fixes #81.