### PR TITLE
Always open result in main window

### DIFF
--- a/info.plist
+++ b/info.plist
@@ -896,10 +896,10 @@ fi</string>
 			<dict>
 				<key>applescript</key>
 				<string>-- This script takes "URLs" of format "identifier,itemID,accountID,itemFolderID,userQuery" or just "userQuery"-- accountID can be the string "null", if so the default account is used-- Some commands need to run twice, otherwise they fail when toolbar search is activeon alfred_script(q)	try		if q contains "/ICNote/p" or q contains "/ICFolder/p" then			set AppleScript's text item delimiters to ","			set identifier to text item 1 of q			set itemID to text item 2 of q			set accountID to text item 3 of q			set itemFolderID to text item 4 of q			set AppleScript's text item delimiters to ""			tell application "Notes"
-				activate				if itemID contains "/ICNote/p" then
+				activate				set index of window 1 where name is "Notes" to 1				if itemID contains "/ICNote/p" then
 					if itemFolderID is not "null" then						if accountID is "null" then							show folder id itemFolderID in default account						else							show folder id itemFolderID in account id accountID						end if
 					end if					-- Show user-requested note					open location "notes://showNote?identifier=" &amp; identifier					open location "notes://showNote?identifier=" &amp; identifier					-- Compatibility with macOS &lt; 11 which does not support notes://					set OSVersion to system version of (system info)					set mainVersion to text 1 thru ((offset of "." in OSVersion) - 1) of OSVersion as number					if mainVersion &lt; 11 then						if accountID is "null" then							show note id itemID in default account							show note id itemID in default account						else							show note id itemID in account id accountID							show note id itemID in account id accountID						end if					end if				else if itemID contains "/ICFolder/p" then					-- Show user-requested folder					if accountID is "null" then						show folder id itemID in default account						show folder id itemID in default account					else						show folder id itemID in account id accountID						show folder id itemID in account id accountID					end if				end if			end tell					else			tell application "Notes"
-				activate
+				activate				set index of window 1 where name is "Notes" to 1
 				show default folder in default account
 				show default folder in default account
 				delay 0.5 -- to avoid any still-pressed keys interfering
@@ -996,7 +996,7 @@ end alfred_script</string>
 on alfred_script(q)
 	try
 		tell application "Notes"
-			activate
+			activate			set index of window 1 where name is "Notes" to 1
 			show default folder in default account
 			show default folder in default account
 			delay 0.5 -- to avoid any still-pressed keys interfering

--- a/info.plist
+++ b/info.plist
@@ -896,10 +896,16 @@ fi</string>
 			<dict>
 				<key>applescript</key>
 				<string>-- This script takes "URLs" of format "identifier,itemID,accountID,itemFolderID,userQuery" or just "userQuery"-- accountID can be the string "null", if so the default account is used-- Some commands need to run twice, otherwise they fail when toolbar search is activeon alfred_script(q)	try		if q contains "/ICNote/p" or q contains "/ICFolder/p" then			set AppleScript's text item delimiters to ","			set identifier to text item 1 of q			set itemID to text item 2 of q			set accountID to text item 3 of q			set itemFolderID to text item 4 of q			set AppleScript's text item delimiters to ""			tell application "Notes"
-				activate				set index of window 1 where name is "Notes" to 1				if itemID contains "/ICNote/p" then
+				activate
+				tell application "System Events"
+					keystroke "0" using command down
+				end tell				if itemID contains "/ICNote/p" then
 					if itemFolderID is not "null" then						if accountID is "null" then							show folder id itemFolderID in default account						else							show folder id itemFolderID in account id accountID						end if
 					end if					-- Show user-requested note					open location "notes://showNote?identifier=" &amp; identifier					open location "notes://showNote?identifier=" &amp; identifier					-- Compatibility with macOS &lt; 11 which does not support notes://					set OSVersion to system version of (system info)					set mainVersion to text 1 thru ((offset of "." in OSVersion) - 1) of OSVersion as number					if mainVersion &lt; 11 then						if accountID is "null" then							show note id itemID in default account							show note id itemID in default account						else							show note id itemID in account id accountID							show note id itemID in account id accountID						end if					end if				else if itemID contains "/ICFolder/p" then					-- Show user-requested folder					if accountID is "null" then						show folder id itemID in default account						show folder id itemID in default account					else						show folder id itemID in account id accountID						show folder id itemID in account id accountID					end if				end if			end tell					else			tell application "Notes"
-				activate				set index of window 1 where name is "Notes" to 1
+				activate
+				tell application "System Events"
+					keystroke "0" using command down
+				end tell
 				show default folder in default account
 				show default folder in default account
 				delay 0.5 -- to avoid any still-pressed keys interfering
@@ -996,7 +1002,10 @@ end alfred_script</string>
 on alfred_script(q)
 	try
 		tell application "Notes"
-			activate			set index of window 1 where name is "Notes" to 1
+			activate
+			tell application "System Events"
+				keystroke "0" using command down
+			end tell
 			show default folder in default account
 			show default folder in default account
 			delay 0.5 -- to avoid any still-pressed keys interfering

--- a/info.plist
+++ b/info.plist
@@ -895,17 +895,19 @@ fi</string>
 			<key>config</key>
 			<dict>
 				<key>applescript</key>
-				<string>-- This script takes "URLs" of format "identifier,itemID,accountID,itemFolderID,userQuery" or just "userQuery"-- accountID can be the string "null", if so the default account is used-- Some commands need to run twice, otherwise they fail when toolbar search is activeon alfred_script(q)	try		if q contains "/ICNote/p" or q contains "/ICFolder/p" then			set AppleScript's text item delimiters to ","			set identifier to text item 1 of q			set itemID to text item 2 of q			set accountID to text item 3 of q			set itemFolderID to text item 4 of q			set AppleScript's text item delimiters to ""			tell application "Notes"
+				<string>-- This script takes "URLs" of format "identifier,itemID,accountID,itemFolderID,userQuery" or just "userQuery"-- accountID can be the string "null", if so the default account is used-- Some commands need to run twice, otherwise they fail when toolbar search is activeon alfred_script(q)	try		if q contains "/ICNote/p" or q contains "/ICFolder/p" then			set AppleScript's text item delimiters to ","			set identifier to text item 1 of q			set itemID to text item 2 of q			set accountID to text item 3 of q			set itemFolderID to text item 4 of q			set AppleScript's text item delimiters to ""
+			tell application "System Events" to tell process "Notes"
 				activate
-				tell application "System Events"
-					keystroke "0" using command down
-				end tell				if itemID contains "/ICNote/p" then
+				set mainWindow to item 1 of ((windows where (name ends with " notes")) &amp; (windows where (name ends with " note")))
+				perform action "AXRaise" of mainWindow
+			end tell			tell application "Notes"				if itemID contains "/ICNote/p" then
 					if itemFolderID is not "null" then						if accountID is "null" then							show folder id itemFolderID in default account						else							show folder id itemFolderID in account id accountID						end if
-					end if					-- Show user-requested note					open location "notes://showNote?identifier=" &amp; identifier					open location "notes://showNote?identifier=" &amp; identifier					-- Compatibility with macOS &lt; 11 which does not support notes://					set OSVersion to system version of (system info)					set mainVersion to text 1 thru ((offset of "." in OSVersion) - 1) of OSVersion as number					if mainVersion &lt; 11 then						if accountID is "null" then							show note id itemID in default account							show note id itemID in default account						else							show note id itemID in account id accountID							show note id itemID in account id accountID						end if					end if				else if itemID contains "/ICFolder/p" then					-- Show user-requested folder					if accountID is "null" then						show folder id itemID in default account						show folder id itemID in default account					else						show folder id itemID in account id accountID						show folder id itemID in account id accountID					end if				end if			end tell					else			tell application "Notes"
+					end if					-- Show user-requested note					open location "notes://showNote?identifier=" &amp; identifier					open location "notes://showNote?identifier=" &amp; identifier					-- Compatibility with macOS &lt; 11 which does not support notes://					set OSVersion to system version of (system info)					set mainVersion to text 1 thru ((offset of "." in OSVersion) - 1) of OSVersion as number					if mainVersion &lt; 11 then						if accountID is "null" then							show note id itemID in default account							show note id itemID in default account						else							show note id itemID in account id accountID							show note id itemID in account id accountID						end if					end if				else if itemID contains "/ICFolder/p" then					-- Show user-requested folder					if accountID is "null" then						show folder id itemID in default account						show folder id itemID in default account					else						show folder id itemID in account id accountID						show folder id itemID in account id accountID					end if				end if			end tell					else
+			tell application "System Events" to tell process "Notes"
 				activate
-				tell application "System Events"
-					keystroke "0" using command down
-				end tell
+				set mainWindow to item 1 of ((windows where (name ends with " notes")) &amp; (windows where (name ends with " note")))
+				perform action "AXRaise" of mainWindow
+			end tell			tell application "Notes"
 				show default folder in default account
 				show default folder in default account
 				delay 0.5 -- to avoid any still-pressed keys interfering
@@ -1001,11 +1003,12 @@ end alfred_script</string>
 
 on alfred_script(q)
 	try
-		tell application "Notes"
+		tell application "System Events" to tell process "Notes"
 			activate
-			tell application "System Events"
-				keystroke "0" using command down
-			end tell
+			set mainWindow to item 1 of ((windows where (name ends with " notes")) &amp; (windows where (name ends with " note")))
+			perform action "AXRaise" of mainWindow
+		end tell
+		tell application "Notes"
 			show default folder in default account
 			show default folder in default account
 			delay 0.5 -- to avoid any still-pressed keys interfering

--- a/info.plist
+++ b/info.plist
@@ -895,9 +895,11 @@ fi</string>
 			<key>config</key>
 			<dict>
 				<key>applescript</key>
-				<string>-- This script takes "URLs" of format "identifier,itemID,accountID,itemFolderID,userQuery" or just "userQuery"-- accountID can be the string "null", if so the default account is used-- Some commands need to run twice, otherwise they fail when toolbar search is activeon alfred_script(q)	try		if q contains "/ICNote/p" or q contains "/ICFolder/p" then			set AppleScript's text item delimiters to ","			set identifier to text item 1 of q			set itemID to text item 2 of q			set accountID to text item 3 of q			set itemFolderID to text item 4 of q			set AppleScript's text item delimiters to ""			tell application "Notes"				if itemID contains "/ICNote/p" then
+				<string>-- This script takes "URLs" of format "identifier,itemID,accountID,itemFolderID,userQuery" or just "userQuery"-- accountID can be the string "null", if so the default account is used-- Some commands need to run twice, otherwise they fail when toolbar search is activeon alfred_script(q)	try		if q contains "/ICNote/p" or q contains "/ICFolder/p" then			set AppleScript's text item delimiters to ","			set identifier to text item 1 of q			set itemID to text item 2 of q			set accountID to text item 3 of q			set itemFolderID to text item 4 of q			set AppleScript's text item delimiters to ""			tell application "Notes"
+				activate				if itemID contains "/ICNote/p" then
 					if itemFolderID is not "null" then						if accountID is "null" then							show folder id itemFolderID in default account						else							show folder id itemFolderID in account id accountID						end if
 					end if					-- Show user-requested note					open location "notes://showNote?identifier=" &amp; identifier					open location "notes://showNote?identifier=" &amp; identifier					-- Compatibility with macOS &lt; 11 which does not support notes://					set OSVersion to system version of (system info)					set mainVersion to text 1 thru ((offset of "." in OSVersion) - 1) of OSVersion as number					if mainVersion &lt; 11 then						if accountID is "null" then							show note id itemID in default account							show note id itemID in default account						else							show note id itemID in account id accountID							show note id itemID in account id accountID						end if					end if				else if itemID contains "/ICFolder/p" then					-- Show user-requested folder					if accountID is "null" then						show folder id itemID in default account						show folder id itemID in default account					else						show folder id itemID in account id accountID						show folder id itemID in account id accountID					end if				end if			end tell					else			tell application "Notes"
+				activate
 				show default folder in default account
 				show default folder in default account
 				delay 0.5 -- to avoid any still-pressed keys interfering
@@ -994,6 +996,7 @@ end alfred_script</string>
 on alfred_script(q)
 	try
 		tell application "Notes"
+			activate
 			show default folder in default account
 			show default folder in default account
 			delay 0.5 -- to avoid any still-pressed keys interfering


### PR DESCRIPTION
# Issue

**When:** You use this workflow to search for a note, but there currently is a note open in its own window, frontmost
**Then:** That frontmost window navigates to the requested note. This is likely unintended (you opened that note in its own window to keep it visible) and even disrupts the navigation history in that window.

# Fix

This change simply focuses the main window before doing any note revealing.

# Notes

The first commit in this PR is from #87.
